### PR TITLE
Fix/ Spotlight card component not scrollable on tablet devices (x768)

### DIFF
--- a/src/lib/demos/components/core/sections/spotlightcard.tsx
+++ b/src/lib/demos/components/core/sections/spotlightcard.tsx
@@ -10,7 +10,7 @@
   export default function SpotlightPage() {
     return (
       <>
-        <main className="relative h-[550px] flex flex-col justify-center bg-slate-900 overflow-hidden">
+        <main className="relative h-[550px] flex flex-col justify-start bg-slate-900 lg:overflow-hidden overflow-auto">
           <div className="w-full max-w-6xl mx-auto px-4 md:px-6 py-24">
   
             <Spotlight className="max-w-sm mx-auto grid gap-6 lg:grid-cols-3 items-start lg:max-w-none group">


### PR DESCRIPTION
**Hi I noticed an Issue where the Spotlight card was not responding on tablets devices, mainly because the component was not scrollable inside the content box.**

I made some fewer styling updates to this component so that it can be scrollable. Please review and let me know if any further changes are required.
 - updated styling to tablets devices
 - tested and confirm everything is still working as intended