### PR TITLE
Updated signature-demo.tsx

### DIFF
--- a/registry/default/demos/signature-demo.tsx
+++ b/registry/default/demos/signature-demo.tsx
@@ -1,5 +1,5 @@
 import { ReactSignature } from "@/registry/default/eldoraui/signature";
 
 export default function PreviewReactSignature() {
-  return <ReactSignature />;
+  return <div className="z-50"><ReactSignature /></div>;
 }


### PR DESCRIPTION
fixed the erase and copy buttons not working in signature component's demo, It was due to z-index of component being lower.